### PR TITLE
IN-967 Expose information about the aws_route.public_internet_gateway resource

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -279,7 +279,7 @@ output "default_vpc_main_route_table_id" {
 //}
 
 output "public_internet_gateway_route" {
-  description = "Exposes informagion about the aws_route which routes traffic over the internet gateway."
+  description = "Exposes information about the aws_route which routes traffic over the internet gateway."
   # Useful to set an explicit dependency on the public subnet being fully configured
-  value = ["${aws_route.public_internet_gateway.route_table_id}", "${aws_route.public_internet_gateway.gateway_id}"]
+  value = "${element(concat(aws_route.public_internet_gateway.*.route_table_id, list("")), 0)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -278,3 +278,8 @@ output "default_vpc_main_route_table_id" {
 //  value       = "${element(concat(aws_default_vpc.this.*.ipv6_cidr_block, list("")), 0)}"
 //}
 
+output "public_internet_gateway_route" {
+  description = "Exposes informagion about the aws_route which routes traffic over the internet gateway."
+  # Useful to set an explicit dependency on the public subnet being fully configured
+  value = ["${aws_route.public_internet_gateway.route_table_id}", "${aws_route.public_internet_gateway.gateway_id}"]
+}


### PR DESCRIPTION
Otherwise there is no way to configure dependencies to force a fully configured public network.